### PR TITLE
Improve vertical charts labels

### DIFF
--- a/components/charts/stacked-bars-vertical/stacked-bars-vertical-component.js
+++ b/components/charts/stacked-bars-vertical/stacked-bars-vertical-component.js
@@ -49,8 +49,9 @@ class StackedBarsVertical extends PureComponent {
           <div className="stacked-bars-vertical-container">
             <div className="bar-wrapper mr-1">
               <div className="score">
-                <div className="text-size-big">2020</div>
-                <span className="current-score">{totalScore.toFixed(2)}<span className="total-score">/{ dataScale.toFixed(2) }</span></span>
+                <div>2020</div>
+                <div className="current-score text-size-big">{ totalScore.toFixed(2) }</div>
+                <span className="total-score">Out of { dataScale.toFixed() }</span>
               </div>
               <div className="bar">
                 <Tooltip
@@ -81,9 +82,9 @@ class StackedBarsVertical extends PureComponent {
             </div>
             <div className={`bar-wrapper bar-wrapper-alt ${ !isPrevYearVisible ? 'bar-wrapper-hidden' : ''}`}>
               <div className="score">
-                <div className="text-size-big">2018</div>
-                <span className="current-score">{totalScore.toFixed(2)}<span
-                  className="total-score">/{ dataScale.toFixed(2) }</span></span>
+                <div>2018</div>
+                <div className="current-score text-size-big">{ totalScore.toFixed(2) }</div>
+                <span className="total-score">Out of { dataScale.toFixed() }</span>
               </div>
               <div className="bar">
 

--- a/components/charts/stacked-bars-vertical/stacked-bars-vertical-styles.scss
+++ b/components/charts/stacked-bars-vertical/stacked-bars-vertical-styles.scss
@@ -86,6 +86,8 @@ $bar-height: 15px;
       margin: 5px 0;
 
       .current-score {
+        margin-top: 5px;
+        margin-bottom: 2px;
         font-weight: $font-weight-bold;
 
         > .total-score {


### PR DESCRIPTION
Closes antistatique/rmi-reports/issues/81

* Make the bottom label span on 2 lines
* Make score more important than year in the top label
