### PR TITLE
Change mobile language menu design

### DIFF
--- a/components/layout/language-bar-mobile/language-bar-mobile-styles.scss
+++ b/components/layout/language-bar-mobile/language-bar-mobile-styles.scss
@@ -2,50 +2,23 @@
 
 .c-language-bar {
   padding: 20px 0;
-  background: $color-7;
-  box-shadow: 0 4px 16px 0 rgba($color-1, .1);
 
   > .languages-list {
-    padding: 0 25px;
-    overflow-x: auto;
-    overflow-y: hidden;
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0 10px;
     white-space: nowrap;
-
-    &:before {
-      content: '';
-      z-index: 2;
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      display: inline-block;
-      width: 25px;
-      background: linear-gradient(to left, rgba($color-7, 0), $color-7);
-    }
-
-    &:after {
-      content: '';
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      display: inline-block;
-      width: 25px;
-      background: linear-gradient(to right, rgba($color-7, 0), $color-7);
-    }
   }
 
   > .languages-list > .languages-item {
     display: inline-block;
-
-    &:not(:first-child) {
-      margin-left: 15px;
-    }
+    width: 50%;
 
     > button {
+      padding: 10px;
       font-family: $font-family-2;
-      font-size: $font-size-smallest;
-      color: rgba($color-1, .5);
+      font-size: $font-size-small;
+      color: $color-7;
       text-transform: uppercase;
     }
 

--- a/components/layout/sidebar/sidebar-styles.scss
+++ b/components/layout/sidebar/sidebar-styles.scss
@@ -14,7 +14,13 @@ $sidebar-gap: 50px;
   overflow-y: auto;
 
   > .sidebar-container {
+    display: flex;
+    flex-direction: column;
     background: $color-2;
+
+    > .l-layout {
+      width: 100%;
+    }
   }
 
   &.-visible {
@@ -61,10 +67,8 @@ $sidebar-gap: 50px;
   }
 
   .language-bar-container {
-    position: fixed;
-    bottom: 0;
-    left: 0;
     width: 100%;
+    margin-top: auto;
 
     @media #{$mq-sm} {
       width: calc(100% - #{$sidebar-gap})


### PR DESCRIPTION
Closes https://github.com/antistatique/rmi-reports/issues/89

This redesign makes the language menu more visible and accessible. This shouldn't break if the client add a few more languages.

Before: 
<img width="340" alt="Capture d’écran 2019-09-23 à 15 35 18" src="https://user-images.githubusercontent.com/10158587/65430242-e63ecc00-de17-11e9-8938-96bd45888f42.png">

After:
<img width="340" alt="Capture d’écran 2019-09-23 à 15 24 10" src="https://user-images.githubusercontent.com/10158587/65429775-0a4ddd80-de17-11e9-899a-1ee53c2b7cd1.png">
