### PR TITLE
Quick access menu fine tuning

### DIFF
--- a/components/common/scroll-spy/scroll-spy-component.js
+++ b/components/common/scroll-spy/scroll-spy-component.js
@@ -68,7 +68,7 @@ class ScrollSpy extends PureComponent {
         duration: 800,
         delay: 0,
         smooth: 'easeInOutQuart',
-        offset: -250
+        offset: -this.props.offset
       });
     }
   }
@@ -82,13 +82,14 @@ class ScrollSpy extends PureComponent {
     const { scrollTop } = this.getScrollDimension();
 
     const rect = el.getBoundingClientRect();
-    const winH = window.innerHeight;
 
-    const scrollBottom = scrollTop + winH;
-    const elTop = rect.top + scrollTop + offset;
+    // The magic +1 is only there to ensure the scrollspy
+    // has enough boundaries when the quick navigation
+    // is scrolling to the element
+    const elTop = (rect.top + scrollTop) - (offset + 1);
     const elBottom = elTop + el.offsetHeight;
 
-    return (elTop < scrollBottom) && (elBottom > scrollTop);
+    return (elTop <= scrollTop) && (elBottom > scrollTop);
   }
 
   render() {

--- a/components/pages/companies-detail/companies-detail-header/companies-detail-header-component.js
+++ b/components/pages/companies-detail/companies-detail-header/companies-detail-header-component.js
@@ -88,6 +88,7 @@ class CompaniesDetailHeader extends PureComponent {
             <div className="row">
               <div className="col-6">
                 <Scrollspy
+                  offset={250}
                   items={[
                     {
                       anchor: 'overall-results',


### PR DESCRIPTION
Fine tune the quick access menu to show the good element.

The Scrollspy takes now the top of the window scroll as a reference to highlight the good element in the quick access dropdown.

Close https://github.com/antistatique/rmi-reports/issues/226