### PR TITLE
Main menu - drop down menu - space fix

### DIFF
--- a/components/layout/header/header-styles.scss
+++ b/components/layout/header/header-styles.scss
@@ -1,7 +1,7 @@
 @import 'css/settings';
 
 .c-header {
-  z-index: 3;
+  z-index: 4;
   position: fixed;
   width: 100%;
   height: $header-height;

--- a/components/layout/header/nav-bar/nav-bar-styles.scss
+++ b/components/layout/header/nav-bar/nav-bar-styles.scss
@@ -128,5 +128,5 @@
 }
 
 .nav-submenu-element {
-  z-index: 3;
+  z-index: 4;
 }


### PR DESCRIPTION
The company detail quick navbar was hovering the main header bar by 3px. Resulting in a space between the dropdown label and his submenu.

This PR adapts the z-index of the header nav components to make the main bar always hover the secondary navigation

Closes https://github.com/antistatique/rmi-reports/issues/221